### PR TITLE
Release 9.0.8

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Pervasive_BWRY_Small
-version=9.0.7
+version=9.0.8
 author=Pervasive Displays Inc.
 maintainer=Arvin Tan <https://www.pervasivedisplays.com/>
 sentence=Driver for Pervasive Displays colour screens 

--- a/src/Pervasive_BWRY_Small.cpp
+++ b/src/Pervasive_BWRY_Small.cpp
@@ -66,6 +66,7 @@ void Pervasive_BWRY_Small::COG_getDataOTP()
         case eScreen_EPD_154_QS_0F: // 1.54”
         case eScreen_EPD_213_QS_0F: // 2.13”
         case eScreen_EPD_266_QS_0F: // 2.66”
+
             _chipId = 0x0302;
             _readBytes = 48;
             break;
@@ -428,7 +429,7 @@ void Pervasive_BWRY_Small::COG_getDataOTP()
     {
         digitalWrite(b_pin.panelCS, LOW); // Select
         COG_data[index] = hV_HAL_SPI3_read(); // Read OTP
-        hV_HAL_log(LEVEL_INFO, "OTP memory [%i] : 0x%02x", index, COG_data[index]);
+        // hV_HAL_log(LEVEL_INFO, "OTP memory [%i] : 0x%02x", index, COG_data[index]);
         digitalWrite(b_pin.panelCS, HIGH); // Unselect
     }
 
@@ -449,6 +450,7 @@ void Pervasive_BWRY_Small::COG_initial()
     switch (u_eScreen_EPD)
     {
         case eScreen_EPD_206_QS_06:
+
             b_sendCommand8(0xa5);
             b_waitBusy();
             b_sendIndexData(0x01, &COG_data[16], 2);
@@ -471,6 +473,7 @@ void Pervasive_BWRY_Small::COG_initial()
         case eScreen_EPD_154_QS_0F: // 1.54”
         case eScreen_EPD_213_QS_0F: // 2.13”
         case eScreen_EPD_266_QS_0F:
+
             b_sendCommand8(0xa5);
             b_waitBusy();
             b_sendIndexData(0x01, &COG_data[16], 1);
@@ -494,6 +497,7 @@ void Pervasive_BWRY_Small::COG_initial()
             break;
 
         case eScreen_EPD_417_QS_0A:
+
             b_sendIndexData(0x01, &COG_data[16], 1);
             b_sendIndexData(0x00, &COG_data[17], 2);
             b_sendIndexData(0x03, &COG_data[30], 3);
@@ -510,6 +514,7 @@ void Pervasive_BWRY_Small::COG_initial()
             b_waitBusy();
 
         case eScreen_EPD_437_QS_0B:
+
             b_sendCommand8(0xa5);
             b_waitBusy();
             b_sendIndexData(0x00, &COG_data[17], 2);
@@ -527,6 +532,7 @@ void Pervasive_BWRY_Small::COG_initial()
             break;
 
         default:
+
             break;
     }
 }
@@ -546,6 +552,7 @@ void Pervasive_BWRY_Small::COG_update()
             break;
 
         case eScreen_EPD_437_QS_0B:
+
             b_sendCommandData8(0xff, 0xa5); //
             b_sendIndexData(0xef, &COG_data[43], 8);
             b_sendCommandData8(0xc3, COG_data[64]);
@@ -594,6 +601,7 @@ void Pervasive_BWRY_Small::COG_stopDCDC()
     switch (u_eScreen_EPD)
     {
         case eScreen_EPD_206_QS_06:
+
             b_sendCommandData8(0x07, 0xa5);
             hV_HAL_delayMilliseconds(50);
             // clear all IOs to LOW
@@ -603,6 +611,7 @@ void Pervasive_BWRY_Small::COG_stopDCDC()
             break;
 
         case eScreen_EPD_266_QS_0F:
+
             // clear all IOs to LOW
             // cut Vcc off
             // delay 100 ms
@@ -611,6 +620,7 @@ void Pervasive_BWRY_Small::COG_stopDCDC()
             break;
 
         case eScreen_EPD_417_QS_0A:
+
             hV_HAL_delayMilliseconds(5000);
             b_sendIndexData(0x00, &COG_data[26], 2); // PSR
             hV_HAL_delayMilliseconds(100);
@@ -621,6 +631,7 @@ void Pervasive_BWRY_Small::COG_stopDCDC()
             break;
 
         case eScreen_EPD_437_QS_0B:
+
             hV_HAL_delayMilliseconds(200);
             // clear all IOs to LOW
             // delay 50 ms

--- a/src/Pervasive_BWRY_Small.cpp
+++ b/src/Pervasive_BWRY_Small.cpp
@@ -22,6 +22,7 @@
 // Release 900: Added new driver library
 // Release 904: Added support for 206-QS-06
 // Release 905: Added support for 437-QS-0B
+// Release 908: Fixed library version with tag 
 //
 
 // Header

--- a/src/Pervasive_BWRY_Small.cpp
+++ b/src/Pervasive_BWRY_Small.cpp
@@ -22,7 +22,7 @@
 // Release 900: Added new driver library
 // Release 904: Added support for 206-QS-06
 // Release 905: Added support for 437-QS-0B
-// Release 908: Fixed library version with tag 
+// Release 908: Fixed library version with tag
 //
 
 // Header
@@ -40,10 +40,12 @@ void Pervasive_BWRY_Small::COG_reset()
     {
         case eScreen_EPD_154_QS_0F: // 1.54”
         case eScreen_EPD_213_QS_0F: // 2.13”
+
             b_reset(10, 10, 20, 40, 10);
             break;
 
         default:
+
             b_reset(20, 10, 20, 10, 10);
             break;
     }
@@ -117,10 +119,12 @@ void Pervasive_BWRY_Small::COG_getDataOTP()
     hV_HAL_GPIO_set(b_pin.panelCS); // Unselect
 
     hV_HAL_Serial_crlf();
-	
+
     if (ui16 == 0x8302)
-	    ui16 = 0x0302;
-	
+    {
+        ui16 = 0x0302;
+    }
+
     if (ui16 == _chipId)
     {
         hV_HAL_log(LEVEL_INFO, "OTP check 1 passed - Chip ID %04x as expected", ui16);

--- a/src/Pervasive_BWRY_Small.h
+++ b/src/Pervasive_BWRY_Small.h
@@ -5,7 +5,7 @@
 /// @details Project Pervasive Displays Library Suite
 /// @n Based on highView technology
 ///
-/// @version 905
+/// @version 908
 ///
 /// @copyright (c) Pervasive Displays Inc., 2021-2026
 /// @copyright All rights reserved
@@ -47,7 +47,7 @@
 ///
 /// @brief Library release number
 ///
-#define DRIVER_BWRY_SMALL_RELEASE 905
+#define DRIVER_BWRY_SMALL_RELEASE 908
 
 ///
 /// @name List of supported screens


### PR DESCRIPTION
Fixed library version with tag

Former release 9.0.7 had unconsistent library version and tag

<img width="2632" height="1464" alt="Capture 2026-04-13 18-44-28" src="https://github.com/user-attachments/assets/8ae1c144-c988-4e24-b281-b87f0ca17c28" />
