### PR TITLE
fix: correct 152-QS-06 reference comment in eScreen_EPD_152_QS_06

### DIFF
--- a/src/Pervasive_BWRY_Small.h
+++ b/src/Pervasive_BWRY_Small.h
@@ -57,7 +57,7 @@
 /// @see https://www.pervasivedisplays.com/products/?_sft_etc_itc=itc&_sft_product_colour=black-white-red-yellow
 /// @{
 ///
-#define eScreen_EPD_152_QS_06 SCREEN(SIZE_152, FILM_Q, DRIVER_6) ///< reference 152-QS-0F
+#define eScreen_EPD_152_QS_06 SCREEN(SIZE_152, FILM_Q, DRIVER_6) ///< reference 152-QS-06
 #define eScreen_EPD_154_QS_0F SCREEN(SIZE_154, FILM_Q, DRIVER_F) ///< reference 154-QS-0F
 #define eScreen_EPD_206_QS_06 SCREEN(SIZE_206, FILM_Q, DRIVER_6) ///< reference 206-QS-06
 #define eScreen_EPD_213_QS_0F SCREEN(SIZE_213, FILM_Q, DRIVER_F) ///< reference 213-QS-0F


### PR DESCRIPTION
Correct the doxygen comment reference from152-QS-0F to 152-QS-06 to match the macro name eScreen_EPD_152_QS_06.

Fixes #11